### PR TITLE
httpallowed->added private 172.16.* class B subnet

### DIFF
--- a/root/defaults/oscam.conf
+++ b/root/defaults/oscam.conf
@@ -10,4 +10,3 @@ logfile                       = stdout
 [webif]
 httpport                      = 8888
 httpallowed                   = 127.0.0.1,192.168.0.0-192.168.255.255,10.0.0.0-10.255.255.255,172.16.0.0-172.31.255.255,255.255.255.255
-https://github.com/linuxserver/docker-oscam/blob/master/root/defaults/oscam.conf

--- a/root/defaults/oscam.conf
+++ b/root/defaults/oscam.conf
@@ -9,4 +9,5 @@ logfile                       = stdout
 
 [webif]
 httpport                      = 8888
-httpallowed                   = 127.0.0.1,192.168.0.0-192.168.255.255,10.0.0.0-10.255.255.255,255.255.255.255
+httpallowed                   = 127.0.0.1,192.168.0.0-192.168.255.255,10.0.0.0-10.255.255.255,172.16.0.0-172.31.255.255,255.255.255.255
+https://github.com/linuxserver/docker-oscam/blob/master/root/defaults/oscam.conf


### PR DESCRIPTION
Ubuntu 18.08 with latest "apt" docker-version (fresh install) defaulted to 172.16.0.1 and .2 addresses, resulting in a "403 access denied" error (webif inaccessible)